### PR TITLE
Support running start-containers.sh within GitLab CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,26 +15,10 @@ env:
   IMAGE_NAME: startnext-cypress
 
 jobs:
-  lint:
-    runs-on: ubuntu-20.04
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Run super-Linter for Dockerfile
-        uses: github/super-linter@v3.13.5
-        env:
-          VALIDATE_DOCKER: yes
-          VALIDATE_DOCKER_HADOLINT: yes
-          FILTER_REGEX_INCLUDE: .*(Dockerfile).*
-          DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   # Run tests.
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
 
   test:
-    needs: lint
     runs-on: ubuntu-20.04
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,35 @@ RUN npm i cypress-file-upload \
 					mocha \
 					mochawesome \
 					mochawesome-report-generator
+
+# From here on, this file describes the environment in which the GitLab runner executes
+# the “start-containers.sh” script from the “startnext-web” repo.
+#
+# This image is not for Docker in Docker, but rather Docker socket binding.
+# See https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#use-docker-socket-binding
+
+# Install Python
+RUN apt-get update -q && apt-get install python3-jinja2 python3-yaml sudo -yq
+
+# Install Docker Engine
+RUN apt-get install \
+         apt-transport-https \
+         ca-certificates \
+         curl \
+         gnupg-agent \
+         software-properties-common -y && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
+    add-apt-repository \
+       "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+       $(lsb_release -cs) \
+       stable" && \
+    apt-get update && \
+    apt-get install docker-ce docker-ce-cli containerd.io -y
+
+# Install Docker-Compose
+RUN curl -L "https://github.com/docker/compose/releases/download/1.28.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
+    chmod +x /usr/local/bin/docker-compose
+
+# Install yq for parsing YAML files
+RUN curl -LsS https://github.com/mikefarah/yq/releases/download/v4.4.1/yq_linux_amd64 -o /usr/bin/yq &&\
+    chmod +x /usr/bin/yq

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,24 +22,24 @@ RUN apt-get update -q && apt-get install python3-jinja2 python3-yaml sudo -yq
 
 # Install Docker Engine
 RUN apt-get install \
-         apt-transport-https \
-         ca-certificates \
-         curl \
-         gnupg \
-         gnupg-agent \
-         lsb-release \
-         software-properties-common -y && \
-    curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
-    echo \
-      "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
-      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
-    apt-get update && \
-    apt-get install docker-ce docker-ce-cli containerd.io -y
+		 apt-transport-https \
+		 ca-certificates \
+		 curl \
+		 gnupg \
+		 gnupg-agent \
+		 lsb-release \
+		 software-properties-common -y && \
+	curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
+	echo \
+	  "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+	  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+	apt-get update && \
+	apt-get install docker-ce docker-ce-cli containerd.io -y
 
 # Install Docker-Compose
 RUN curl -L "https://github.com/docker/compose/releases/download/1.28.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
-    chmod +x /usr/local/bin/docker-compose
+	chmod +x /usr/local/bin/docker-compose
 
 # Install yq for parsing YAML files
 RUN curl -LsS https://github.com/mikefarah/yq/releases/download/v4.4.1/yq_linux_amd64 -o /usr/bin/yq &&\
-    chmod +x /usr/bin/yq
+	chmod +x /usr/bin/yq

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN npm i cypress-file-upload \
 # This image is not for Docker in Docker, but rather Docker socket binding.
 # See https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#use-docker-socket-binding
 
-# Install Python
+# Install Python for fill_with_jinja.py
 RUN apt-get update -q && apt-get install python3-jinja2 python3-yaml sudo -yq
 
 # Install Docker Engine
@@ -25,13 +25,14 @@ RUN apt-get install \
          apt-transport-https \
          ca-certificates \
          curl \
+         gnupg \
          gnupg-agent \
+         lsb-release \
          software-properties-common -y && \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    add-apt-repository \
-       "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-       $(lsb_release -cs) \
-       stable" && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
+    echo \
+      "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
     apt-get update && \
     apt-get install docker-ce docker-ce-cli containerd.io -y
 


### PR DESCRIPTION
I hope this makes running Cypress tests for review apps (=branch webs) super easy.

https://equify.de/Portal/m/1073035/eq/Cypress-Tests-so-konfigurieren-dass-sie-automatisiert-im-Abnahmeweb-laufen

Hi @eknej :wave: :blush: 