### PR TITLE
Migrate to docker actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,18 +38,15 @@ jobs:
   test:
     needs: lint
     runs-on: ubuntu-latest
-
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v2
-
-      - name: Run tests
-        run: |
-          if [ -f docker-compose.test.yml ]; then
-            docker-compose --file docker-compose.test.yml build
-            docker-compose --file docker-compose.test.yml run sut
-          else
-            docker build . --file Dockerfile
-          fi
+        with:
+          fetch-depth: 1
+      - name: Test build
+        uses: docker/build-push-action@v2
+        with:
+          push: false
 
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ on:
   pull_request:
 
 env:
-  IMAGE_NAME: startnext-cypress
+  REGISTRY: ghcr.io
 
 jobs:
   # Run tests.
@@ -47,49 +47,53 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/
-  push:
+  build-push:
     # Ensure test job passes before pushing image.
     needs: lint
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
-
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME
-
-      - name: Log into GitHub Container Registry
-        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Push image to GitHub Container Registry
-        run: |
-          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
-          IMAGE_ID_LONG=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME/$IMAGE_NAME
-
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          IMAGE_ID_LONG=$(echo $IMAGE_ID_LONG | tr '[A-Z]' '[a-z]')
-
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-
-          # Set Docker rolling tags bleeding/latest
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION_ROLLING=latest
-          [ "$VERSION" == "main" ] && VERSION_ROLLING=bleeding
-
-          # Set Commit Short SHA (first seven char) as VERSION for bleeding builds
-          [ "$VERSION" == "main" ] && VERSION=${GITHUB_SHA:0:7}
-
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-          echo VERSION_ROLLING=$VERSION_ROLLING
-
-          docker tag $IMAGE_NAME $IMAGE_ID_LONG:$VERSION
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker tag $IMAGE_NAME $IMAGE_ID_LONG:$VERSION_ROLLING
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION_ROLLING
-          docker push $IMAGE_ID_LONG:$VERSION
-          docker push $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID_LONG:$VERSION_ROLLING
-          docker push $IMAGE_ID:$VERSION_ROLLING
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Login into Container Registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata for Docker (tag)
+        id: meta_tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
+          tags: |
+            type=ref,event=tag
+      - name: Extract metadata for Docker (bleeding)
+        id: meta_bleeding
+        if: false == startsWith(github.ref, 'refs/tags/v')
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}
+          tags: |
+            type=edge
+            type=sha,prefix=
+      - name: Build and push Docker image (tag)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.meta_tag.outputs.tags }}
+          labels: ${{ steps.meta_tag.outputs.labels }}
+      - name: Build and push Docker image (bleeding)
+        if: false == startsWith(github.ref, 'refs/tags/v')
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.meta_bleeding.outputs.tags }}
+          labels: ${{ steps.meta_bleeding.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -35,7 +35,7 @@ jobs:
 
   test:
     needs: lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -55,7 +55,7 @@ jobs:
     # Ensure test job passes before pushing image.
     needs: test
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event_name == 'push'
 
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,9 +15,23 @@ env:
   IMAGE_NAME: startnext-cypress
 
 jobs:
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Test build
+        uses: docker/build-push-action@v2
+        with:
+          push: false
   lint:
     runs-on: ubuntu-latest
-
+    if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -31,29 +45,11 @@ jobs:
           FILTER_REGEX_INCLUDE: .*(Dockerfile).*
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # Run tests.
-  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
-
-  test:
-    needs: lint
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-      - name: Test build
-        uses: docker/build-push-action@v2
-        with:
-          push: false
-
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/
   push:
     # Ensure test job passes before pushing image.
-    needs: test
-
+    needs: lint
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,8 +21,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Run super-Linter for Dockerfile
-        uses: github/super-linter@v3.13.5
+        uses: github/super-linter@v4
         env:
           VALIDATE_DOCKER: yes
           VALIDATE_DOCKER_HADOLINT: yes

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,7 @@
 ## Startnext Crowdfunding GmbH
 
 - Jörg Jenke <joerg.jenke@startnext.com>
+
+## Tyclipso GmbH
+
+- Christoph Kepler <christoph.kepler@tyclipso.net>


### PR DESCRIPTION
This PR rewrites the docker workflow to use docker/*-actions instead of manual runs.
This should address the push issue.

Uses:

- docker/build-push-action@v2
- docker/login-action@v2
- docker/metadata-action@v3
- docker/build-push-action@v2

Additional changes:

- Use super-linter@v4 for smaller docker image and therefor quicker execution
- Run test build step only on PR
- Run (super)hadolint not on PR (should be sufficient with the lint workflow)