### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,5 @@ RUN su node -c 'mkdir -p /home/node/.config/fontconfig' && \
             <const>lcdnone</const> \
           </edit> \
         </match> \
-      </fontconfig>' > /home/node/.config/fontconfig/fonts.conf
+      </fontconfig>' > /home/node/.config/fontconfig/fonts.conf && \
+    echo 'cp /usr/app/* . -r' | su node -c 'tee /home/node/.bashrc'

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,3 +14,20 @@ RUN npm i cypress-file-upload \
 					mocha \
 					mochawesome \
 					mochawesome-report-generator
+
+RUN su node -c 'mkdir -p /home/node/.config/fontconfig' && \
+    echo '<?xml version="1.0"?> \
+      <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd"> \
+      <fontconfig> \
+        <match target="font"> \
+          <edit name="antialias" mode="assign"> \
+            <bool>false</bool> \
+          </edit> \
+          <edit name="hintstyle" mode="assign"> \
+            <const>hintnone</const> \
+          </edit> \
+          <edit name="lcdfilter" mode="assign"> \
+            <const>lcdnone</const> \
+          </edit> \
+        </match> \
+      </fontconfig>' > /home/node/.config/fontconfig/fonts.conf


### PR DESCRIPTION
fix: prevent anti-alias, hinting and sub-pixel color fringes

Equify: https://equify.de/Portal/m/1349644/eq/Cypres-Tests-Grautoene-und-zufaellige-Farben-in-Schriften-verhindern
    
This should increase reliability of visual regression testing.